### PR TITLE
scoring correction - points awarded on death

### DIFF
--- a/src/supremacy/engine.py
+++ b/src/supremacy/engine.py
@@ -245,8 +245,8 @@ class Engine:
                     self.players[name].remove_base(uid)
             if len(self.players[name].bases) == 0:
                 print(f"Player {name} died!")
-                self.dead_players.append(name)
                 self.players[name].update_score(len(self.dead_players))
+                self.dead_players.append(name)
                 self.players[name].rip()
                 rip_players.append(name)
         if dead_bases:


### PR DESCRIPTION
Synchronizing scoring mechanism with the description - when a player dies, they only gets as many points as many players dies before them (themselves excluded).
This correction also avoids surviving players getting the same amount of points as the player that dies last before the game ends.

Example scenario:
Alice, Bob and Charlie are the players. In an unusually boring party, Alice destroys Bob's only base, killing Bob, and then nothing happens in the rest of the game. 

How the scoring works without the fix:
Alice gets 1 point for destroying Bob's base.
Bob gets 1 point upon his death.
Alice and Charlie both get 1 point for survival at the end of the match.
Total: Alice 2, Bob 1, Charlie 1

How the scoring works without the fix:
Alice gets 1 point for destroying Bob's base.
Bob does not get any points upon his death (as there was no player dying before him).
Alice and Charlie both get 1 point for survival at the end of the match.
Total: Alice 2, Bob 0, Charlie 1
