### PR TITLE
dumped player map views use same orientation as the map itself

### DIFF
--- a/src/supremacy/player.py
+++ b/src/supremacy/player.py
@@ -5,7 +5,7 @@ from itertools import chain
 from typing import Any, Iterator, Tuple
 
 import numpy as np
-from PIL import Image, ImageOps
+from PIL import Image
 import pyglet
 
 from . import config
@@ -190,8 +190,7 @@ class Player:
         self.make_avatar_base_image()
 
     def dump_map(self):
-        im = Image.fromarray((self.game_map.array.astype(np.uint8) + 1) * 127)
-        im = ImageOps.flip(im)
+        im = Image.fromarray(np.flipud((self.game_map.array.astype(np.uint8) + 1) * 127))
         im.save(f"{self.team}_map.png")
 
     def init_cross_animation(self):

--- a/src/supremacy/player.py
+++ b/src/supremacy/player.py
@@ -5,7 +5,7 @@ from itertools import chain
 from typing import Any, Iterator, Tuple
 
 import numpy as np
-from PIL import Image
+from PIL import Image, ImageOps
 import pyglet
 
 from . import config
@@ -191,6 +191,7 @@ class Player:
 
     def dump_map(self):
         im = Image.fromarray((self.game_map.array.astype(np.uint8) + 1) * 127)
+        im = ImageOps.flip(im)
         im.save(f"{self.team}_map.png")
 
     def init_cross_animation(self):


### PR DESCRIPTION
ground truth:
![ground_truth](https://github.com/europython2023gametournament/supremacy/assets/4532150/8566b772-79f4-4537-8ed4-108bb84b34be)
player's view without the fix:
![Isobel_unflippedmap](https://github.com/europython2023gametournament/supremacy/assets/4532150/69a8d657-eaf8-4060-aeab-a02236eedf6d)
player's view with the fix:
![Isobel_map](https://github.com/europython2023gametournament/supremacy/assets/4532150/348df5de-e63a-411a-a70a-2ee6c824d29a)
